### PR TITLE
Added in alignment expansion support

### DIFF
--- a/src/components/GridSection/GridSection.css
+++ b/src/components/GridSection/GridSection.css
@@ -6,14 +6,23 @@
   /* Ensure it takes full height */
 }
 
-.grid-item.top {
+.grid-item.y-top {
   align-items: flex-start;
 }
 
-.grid-item.middle {
+.grid-item.y-middle,
+.grid-item.y-center {
   align-items: center;
 }
 
-.grid-item.bottom {
+.grid-item.y-bottom {
   align-items: flex-end;
+}
+
+.grid-item.x-left {
+  justify-content: left;
+}
+
+.grid-item.x-right {
+  justify-content: right;
 }

--- a/src/components/GridSection/GridSection.stories.tsx
+++ b/src/components/GridSection/GridSection.stories.tsx
@@ -59,3 +59,15 @@ let BreakPointSectionProps: GridSectionProps = {
 };
 
 BreakPoint.args = BreakPointSectionProps;
+
+export const alignment = Template.bind({});
+
+let alignmentPercentSection: GridSectionProps = {
+  cover: 100,
+  content: <div style={{ width: "100px", height: "100px", background: "#F8D800" }}>Small Square</div>,
+  xAlign: 'align',
+  yAlign: 'align',
+};
+
+alignment.args = alignmentPercentSection;
+

--- a/src/components/GridSection/GridSection.tsx
+++ b/src/components/GridSection/GridSection.tsx
@@ -1,5 +1,5 @@
 import React, { useId } from "react";
-import { Display, GridSectionProps } from "../../types";
+import { Display, GridSectionProps, xAlignValue, yAlignValue } from "../../types";
 import "./GridSection.css"
 import Grid from "../Grid";
 import { useBreakpoint } from "../../breakpoint";
@@ -43,10 +43,36 @@ const GridSection: React.FC<GridSectionProps> = (props) => {
   }
   if (display === "hide") return null;
 
+  /**
+   * Alignment Support is part of 3
+   */
+  let xAlign: xAlignValue | undefined = "left";
+  let yAlign: yAlignValue | undefined = "top";
+
+  if (props.align) {
+    if (props.align.includes("-")) {
+      const splitAlign = props.align.split("-");
+      xAlign = splitAlign[0] as xAlignValue;
+      yAlign = splitAlign[1] as yAlignValue;
+    } else {
+      xAlign = 'center';
+      yAlign = props.align as yAlignValue;
+    }
+  }
+
+  if (props.yAlign && props.yAlign != 'align') {
+    yAlign = props.yAlign
+  }
+
+  if (props.xAlign && props.xAlign != 'align') {
+    xAlign = props.xAlign;
+  }
+
+
   return (
     <div
       key={uniqueKey}
-      className={`grid-item ${props.align}`}
+      className={`grid-item ${"x-" + xAlign} ${"y-" + yAlign}`}
       style={{ flexBasis: `${props.cover}%`, flexGrow: 0, flexShrink: 0, height: "100%" }}
     >
       {props.content &&

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,7 @@ export interface GridSectionProps {
      */
     parentAlignment?: parentAlignment;
     /**
-     * Alignment placement inside gridk
+     * Alignment placement inside grid
      */
     align?:
     'center-top' | 'middle-top' | 'left-top' | 'right-top' |

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,9 +88,25 @@ export interface GridSectionProps {
      */
     parentAlignment?: parentAlignment;
     /**
-     * Alignment placement inside grid
+     * Alignment placement inside gridk
      */
-    align: 'top' | 'middle' | 'bottom';
+    align?:
+    'center-top' | 'middle-top' | 'left-top' | 'right-top' |
+    'center-middle' |  'middle-middle' |  'left-middle' |  'right-middle' |
+    'center-center' | 'middle-center' | 'left-center' | 'right-center' | 
+    'center-bottom' | 'middle-bottom' | 'left-bottom' | 'right-bottom' | 'top' | 'middle' | 'center' | 'bottom';
+
+    /**
+     * Y Axis Alignment placement inside grid
+     * (warning this will override `align`)
+     */
+    yAlign?: yAlignValue;
+
+    /**
+     * X Axis Alignment placement inside grid
+     * (warning this will override `align`)
+     */
+    xAlign?: xAlignValue;
     /**
      * Inside grid section support (Use for Grid inside Grid cases)
      */
@@ -129,3 +145,7 @@ export interface GridSectionProps {
 export type Display = "show" | "hide" | "default";
 
 export type BreakpointValue = "xs" | "sm" | "md" | "lg" | "xl" | "xxl" | "xxxl" | "default";
+
+export type yAlignValue = 'top' | 'middle' | 'center' | 'bottom' | 'align';
+
+export type xAlignValue = 'left' | 'middle' | 'center' | 'right' | 'align';


### PR DESCRIPTION

https://github.com/Juice-Box-Monkey-Designs/grid-matrix/assets/3589463/ff2fe17d-2b84-4052-b2ef-8c12e59a489a

`align`  - allow `{{xAlign}}-{{yAlign}}` settings (ex. `left-top` which is left side at the top )

`xAlign` -  Set x setting on alignment (overrides align)

`yAlign` - Set y setting on alignment (overrides align)